### PR TITLE
Update NSubstitute package to 1.6.1.0

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/AutofacContrib.NSubstitute.Tests.csproj
+++ b/AutofacContrib.NSubstitute.Tests/AutofacContrib.NSubstitute.Tests.csproj
@@ -41,9 +41,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.3.0.2\lib\net40\Autofac.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.6.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NSubstitute.1.6.0.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute">
+      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/AutofacContrib.NSubstitute.Tests/packages.config
+++ b/AutofacContrib.NSubstitute.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.0.2" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.0.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
 </packages>

--- a/AutofacContrib.NSubstitute/AutofacContrib.NSubstitute.csproj
+++ b/AutofacContrib.NSubstitute/AutofacContrib.NSubstitute.csproj
@@ -49,9 +49,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.3.0.2\lib\net40\Autofac.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.6.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NSubstitute.1.6.0.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute">
+      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/AutofacContrib.NSubstitute/packages.config
+++ b/AutofacContrib.NSubstitute/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.0.2" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.0.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
All tests pass. I get assembly load errors after updating TestStack.Seleno to NSubstitute 1.6.1.0 where AutofacContrib was attempting to load 1.6.0.0 and refused to see 1.6.1.0 as sufficient.
