### PR TITLE
Upgrade Autofac and fix decorator service issue

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/AutofacContrib.NSubstitute.Tests.csproj
+++ b/AutofacContrib.NSubstitute.Tests/AutofacContrib.NSubstitute.Tests.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.9.4.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.9.4\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>

--- a/AutofacContrib.NSubstitute.Tests/packages.config
+++ b/AutofacContrib.NSubstitute.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.6.2" targetFramework="net452" />
+  <package id="Autofac" version="4.9.4" targetFramework="net452" />
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />

--- a/AutofacContrib.NSubstitute/AutofacContrib.NSubstitute.csproj
+++ b/AutofacContrib.NSubstitute/AutofacContrib.NSubstitute.csproj
@@ -44,8 +44,8 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.9.4.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.9.4\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>

--- a/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
+++ b/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Autofac;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Features.Decorators;
 using NSubstitute;
 
 namespace AutofacContrib.NSubstitute
@@ -29,6 +30,10 @@ namespace AutofacContrib.NSubstitute
         /// <returns>
         ///     Registrations for the service.
         /// </returns>
+        /// <remarks>
+        ///     Since Autofac v4.9.0 the DecoratorService also passed though this
+        ///     registration source, make sure this is not mocked out by a proxy.
+        /// </remarks>
         public IEnumerable<IComponentRegistration> RegistrationsFor
             (Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
@@ -40,7 +45,8 @@ namespace AutofacContrib.NSubstitute
                 !typedService.ServiceType.IsInterface ||
                 IsGenericListOrCollectionInterface(typedService.ServiceType) ||
                 typedService.ServiceType.IsArray ||
-                typeof(IStartable).IsAssignableFrom(typedService.ServiceType))
+                typeof(IStartable).IsAssignableFrom(typedService.ServiceType) ||
+                service is DecoratorService)
                 return Enumerable.Empty<IComponentRegistration>();
 
             var rb = RegistrationBuilder.ForDelegate((c, p) => Substitute.For(new[] {typedService.ServiceType}, null))

--- a/AutofacContrib.NSubstitute/packages.config
+++ b/AutofacContrib.NSubstitute/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.6.2" targetFramework="net452" />
+  <package id="Autofac" version="4.9.4" targetFramework="net452" />
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />


### PR DESCRIPTION
Upgrade Autofac to the latest version and fix an issue where all services are resolved as mocks because the Autofac decorator service was also mocked out.