### PR TITLE
Add overload to SubstituteForBuilder<> that allows configuration of substitute with access to Autofac container

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/ExampleFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/ExampleFixture.cs
@@ -185,35 +185,6 @@ namespace AutofacContrib.NSubstitute.Tests
         }
 
         [Test]
-        public void SubstituteForAndProvide()
-        {
-            const int val = 2;
-
-            using var utoSubstitute = AutoSubstitute.Configure()
-                .SubstituteFor<ConcreteClass>(val).Provide(out var concreteClass).Configured()
-                .Build()
-                .Container;
-
-            concreteClass.Value.AssertIsNSubstituteMock();
-            Assert.AreSame(concreteClass.Value, utoSubstitute.Resolve<ConcreteClass>());
-        }
-
-        [Test]
-        public void SubstituteTwice()
-        {
-            const int val = 2;
-
-            using var utoSubstitute = AutoSubstitute.Configure()
-                .SubstituteFor<ConcreteClass>(val).Provide(out var concreteClass1).Configured()
-                .SubstituteFor<ConcreteClass>(val).Provide(out var concreteClass2).Configured()
-                .Build()
-                .Container;
-
-            concreteClass1.Value.AssertIsNSubstituteMock();
-            Assert.AreSame(concreteClass1.Value, concreteClass2.Value);
-        }
-
-        [Test]
         public void SubstituteForConfigureWithContext()
         {
             const int val = 2;

--- a/AutofacContrib.NSubstitute.Tests/ExampleFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/ExampleFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using NSubstitute;
+using NSubstitute.Extensions;
 using NUnit.Framework;
 
 namespace AutofacContrib.NSubstitute.Tests
@@ -38,6 +39,14 @@ namespace AutofacContrib.NSubstitute.Tests
         public int AMethod()
         {
             return _d1.SomeMethod(_d2.SomeOtherMethod());
+        }
+    }
+
+    public class ConcreteClassWithObject
+    {
+        public virtual object GetResult()
+        {
+            return new object();
         }
     }
 
@@ -173,6 +182,54 @@ namespace AutofacContrib.NSubstitute.Tests
             var result = utoSubstitute.Resolve<MyClassWithConcreteDependency>().AMethod();
 
             Assert.That(result, Is.EqualTo(val3));
+        }
+
+        [Test]
+        public void SubstituteForAndProvide()
+        {
+            const int val = 2;
+
+            using var utoSubstitute = AutoSubstitute.Configure()
+                .SubstituteFor<ConcreteClass>(val).Provide(out var concreteClass).Configured()
+                .Build()
+                .Container;
+
+            concreteClass.Value.AssertIsNSubstituteMock();
+            Assert.AreSame(concreteClass.Value, utoSubstitute.Resolve<ConcreteClass>());
+        }
+
+        [Test]
+        public void SubstituteTwice()
+        {
+            const int val = 2;
+
+            using var utoSubstitute = AutoSubstitute.Configure()
+                .SubstituteFor<ConcreteClass>(val).Provide(out var concreteClass1).Configured()
+                .SubstituteFor<ConcreteClass>(val).Provide(out var concreteClass2).Configured()
+                .Build()
+                .Container;
+
+            concreteClass1.Value.AssertIsNSubstituteMock();
+            Assert.AreSame(concreteClass1.Value, concreteClass2.Value);
+        }
+
+        [Test]
+        public void SubstituteForConfigureWithContext()
+        {
+            const int val = 2;
+
+            using var utoSubstitute = AutoSubstitute.Configure()
+                .SubstituteFor<ConcreteClass>(val).Configured()
+                .SubstituteFor<ConcreteClassWithObject>().Configure((s, ctx) =>
+                {
+                    s.Configure().GetResult().Returns(ctx.Resolve<ConcreteClass>());
+                })
+                .Build()
+                .Container;
+
+            var result = utoSubstitute.Resolve<ConcreteClassWithObject>().GetResult();
+
+            Assert.AreSame(result, utoSubstitute.Resolve<ConcreteClass>());
         }
 
         [Test]

--- a/AutofacContrib.NSubstitute.Tests/NSubstituteExtensions.cs
+++ b/AutofacContrib.NSubstitute.Tests/NSubstituteExtensions.cs
@@ -1,0 +1,13 @@
+﻿using NSubstitute.Extensions;
+
+namespace AutofacContrib.NSubstitute.Tests
+{
+    internal static class NSubstituteExtensions
+    {
+        public static void AssertIsNSubstituteMock(this object obj)
+        {
+            // This throws an exception if it is not an NSubstitute mock
+            obj.Configure();
+        }
+    }
+}

--- a/AutofacContrib.NSubstitute/SubstituteForBuilder.cs
+++ b/AutofacContrib.NSubstitute/SubstituteForBuilder.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Autofac;
+using Autofac.Builder;
+using System;
 
 namespace AutofacContrib.NSubstitute
 {
@@ -10,12 +12,12 @@ namespace AutofacContrib.NSubstitute
         where TService : class
     {
         private readonly AutoSubstituteBuilder _builder;
-        private readonly TService _service;
+        private readonly IRegistrationBuilder<TService, SimpleActivatorData, SingleRegistrationStyle> _registration;
 
-        internal SubstituteForBuilder(AutoSubstituteBuilder builder, TService service)
+        internal SubstituteForBuilder(AutoSubstituteBuilder builder, IRegistrationBuilder<TService, SimpleActivatorData, SingleRegistrationStyle> registration)
         {
             _builder = builder;
-            _service = service;
+            _registration = registration;
         }
 
         /// <summary>
@@ -24,10 +26,41 @@ namespace AutofacContrib.NSubstitute
         /// <param name="action">The delegate to configure the service.</param>
         /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
         public AutoSubstituteBuilder Configure(Action<TService> action)
+            => Configure((s, _) => action(s));
+
+        /// <summary>
+        /// Allows for configuration of the service with access to the resolved components.
+        /// </summary>
+        /// <param name="action">The delegate to configure the service.</param>
+        /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
+        public AutoSubstituteBuilder Configure(Action<TService, IComponentContext> action)
         {
-            action(_service);
+            _registration.OnActivated(args =>
+            {
+                action(args.Instance, args.Context);
+            });
+
             return _builder;
         }
-    }
 
+        /// <summary>
+        /// Completes the configuration of the substitute.
+        /// </summary>
+        /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
+        public AutoSubstituteBuilder Configured()
+        {
+            return _builder;
+        }
+
+        /// <summary>
+        /// Allows a way to access the services being configured that the container will provide.
+        /// </summary>
+        /// <param name="service">Parameter to obtain the substituted value.</param>
+        /// <returns></returns>
+        public SubstituteForBuilder<TService> Provide(out IProvidedValue<TService> service)
+        {
+            service = _builder.CreateProvidedValue(c => c.Resolve<TService>());
+            return this;
+        }
+    }
 }

--- a/AutofacContrib.NSubstitute/SubstituteForBuilder.cs
+++ b/AutofacContrib.NSubstitute/SubstituteForBuilder.cs
@@ -47,20 +47,6 @@ namespace AutofacContrib.NSubstitute
         /// Completes the configuration of the substitute.
         /// </summary>
         /// <returns>The original <see cref="AutoSubstituteBuilder"/>.</returns>
-        public AutoSubstituteBuilder Configured()
-        {
-            return _builder;
-        }
-
-        /// <summary>
-        /// Allows a way to access the services being configured that the container will provide.
-        /// </summary>
-        /// <param name="service">Parameter to obtain the substituted value.</param>
-        /// <returns></returns>
-        public SubstituteForBuilder<TService> Provide(out IProvidedValue<TService> service)
-        {
-            service = _builder.CreateProvidedValue(c => c.Resolve<TService>());
-            return this;
-        }
+        public AutoSubstituteBuilder Configured() => _builder;
     }
 }

--- a/README.md
+++ b/README.md
@@ -164,6 +164,29 @@ public void Example_test_with_substitute_for_concrete()
 }
 ```
 
+If you want to configure it with a service from the container, you can use a separate overload:
+
+```c#
+[Test]
+public void SubstituteForConfigureWithContext()
+{
+	const int val = 2;
+
+	using var utoSubstitute = AutoSubstitute.Configure()
+		.SubstituteFor<ConcreteClass>(val).Configured()
+		.SubstituteFor<ConcreteClassWithObject>().Configure((s, ctx) =>
+		{
+			s.Configure().GetResult().Returns(ctx.Resolve<ConcreteClass>());
+		})
+		.Build()
+		.Container;
+
+	var result = utoSubstitute.Resolve<ConcreteClassWithObject>().GetResult();
+
+	Assert.AreSame(result, utoSubstitute.Resolve<ConcreteClass>());
+}
+```
+
 Similarly, you can resolve a concrete type from the autosubstitute container and register that with the underlying container using the `ResolveAndSubstituteFor` method:
 
 ```c#


### PR DESCRIPTION
This allows a fluent syntax to retrieve values that have been configured using NSubstitute