### PR TITLE
Enable customization of the registration sources via a configurable options object

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/AutoSubstituteOptionsFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/AutoSubstituteOptionsFixture.cs
@@ -1,0 +1,142 @@
+﻿using Autofac;
+using Autofac.Core;
+using NUnit.Framework;
+
+namespace AutofacContrib.NSubstitute.Tests
+{
+    [TestFixture]
+    public class AutoSubstituteOptionsFixture
+    {
+        [Test]
+        public void NoInjectPropertiesInterface()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .Build()
+                .Container;
+
+            var testInterface1 = mock.Resolve<ITestInterface1>();
+            var class1 = mock.Resolve<Class1>();
+
+            Assert.AreNotSame(class1, testInterface1.Instance);
+        }
+
+        [Test]
+        public void InjectPropertiesInterface()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .InjectProperties()
+                .Build()
+                .Container;
+
+            var testInterface1 = mock.Resolve<ITestInterface1>();
+
+            Assert.That(testInterface1.Instance, Is.TypeOf<Class1>());
+        }
+
+        [Test]
+        public void InjectPropertiesInterfaceWithUnregisteredPerLifetime()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .InjectProperties()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build()
+                .Container;
+
+            var class1 = mock.Resolve<Class1>();
+            var testInterface1 = mock.Resolve<ITestInterface1>();
+
+            Assert.AreSame(class1, testInterface1.Instance);
+        }
+
+        [Test]
+        public void NoInjectPropertiesClass()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .Build()
+                .Container;
+
+            var obj = mock.Resolve<WithProperties>();
+
+            Assert.IsNull(obj.Service);
+        }
+
+        [Test]
+        public void InjectPropertiesClass()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .InjectProperties()
+                .Build()
+                .Container;
+
+            var obj = mock.Resolve<WithProperties>();
+
+            Assert.IsNotNull(obj.Service);
+        }
+
+        [Test]
+        public void InjectPropertiesInterfaceRecursive()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .InjectProperties()
+                .MakeUnregisteredTypesPerLifetime()
+                .Build()
+                .Container;
+
+            var obj = mock.Resolve<ITestInterfaceRecursive>();
+
+            Assert.AreSame(obj, obj.Instance.Recursive);
+        }
+
+        [Test]
+        public void InternalConstructorFails()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .Build()
+                .Container;
+
+            Assert.Throws<DependencyResolutionException>(() => mock.Resolve<ClassWithInternalConstructor>());
+        }
+
+        [Test]
+        public void InternalConstructorSucceeds()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .UnregisteredTypesUseInternalConstructor()
+                .Build()
+                .Container;
+
+            Assert.NotNull(mock.Resolve<ClassWithInternalConstructor>());
+        }
+
+        public interface ITestInterface1
+        {
+            Class1 Instance { get; }
+        }
+
+        public class WithProperties
+        {
+            public ITestInterface1 Service { get; set; }
+        }
+
+        public class Class1
+        {
+        }
+
+        public interface ITestInterfaceRecursive
+        {
+            ClassRecursive Instance { get; }
+        }
+
+        public class ClassRecursive
+        {
+            public ITestInterfaceRecursive Recursive { get; set; }
+        }
+
+        public class ClassWithInternalConstructor
+        {
+            internal ClassWithInternalConstructor()
+            {
+            }
+        }
+    }
+}

--- a/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
@@ -11,11 +11,13 @@ namespace AutofacContrib.NSubstitute
     {
         private readonly List<IProvidedValue> _providedValues;
         private readonly ContainerBuilder _builder;
+        private readonly AutoSubstituteOptions _options;
 
         public AutoSubstituteBuilder()
         {
             _builder = new ContainerBuilder();
             _providedValues = new List<IProvidedValue>();
+            _options = new AutoSubstituteOptions();
         }
 
         public AutoSubstitute Build()
@@ -23,8 +25,17 @@ namespace AutofacContrib.NSubstitute
 
         internal IContainer InternalBuild()
         {
-            _builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
-            _builder.RegisterSource(new NSubstituteRegistrationHandler());
+            _builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource
+            {
+                RegistrationConfiguration = c =>
+                {
+                    foreach (var configure in _options.ConfigureAnyConcreteTypeRegistration)
+                    {
+                        configure(c);
+                    }
+                }
+            });
+            _builder.RegisterSource(new NSubstituteRegistrationHandler(_options));
 
             var container = _builder.Build();
 
@@ -34,6 +45,17 @@ namespace AutofacContrib.NSubstitute
             }
 
             return container;
+        }
+
+        /// <summary>
+        /// Configures the option associated with this substitue builder.
+        /// </summary>
+        /// <param name="action">A delegate that configures the <see cref="AutoSubstituteOptions"/>.</param>
+        /// <returns>The <see cref="AutoSubstituteBuilder"/>.</returns>
+        public AutoSubstituteBuilder ConfigureOptions(Action<AutoSubstituteOptions> action)
+        {
+            action(_options);
+            return this;
         }
 
         /// <summary>

--- a/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
@@ -1,0 +1,19 @@
+﻿using Autofac.Builder;
+using System;
+using System.Collections.Generic;
+
+namespace AutofacContrib.NSubstitute
+{
+    public class AutoSubstituteOptions
+    {
+        /// <summary>
+        /// Gets a collection of handlers that can be used to modify mocks after they are created.
+        /// </summary>
+        public ICollection<MockHandler> MockHandlers { get; } = new List<MockHandler>();
+
+        /// <summary>
+        /// Gets a collection of delegates that can augment the registrations of objects created but not registered.
+        /// </summary>
+        public ICollection<Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>> ConfigureAnyConcreteTypeRegistration { get; } = new List<Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>>(); 
+    }
+}

--- a/AutofacContrib.NSubstitute/AutoSubstituteOptionsExtensions.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteOptionsExtensions.cs
@@ -54,9 +54,9 @@ namespace AutofacContrib.NSubstitute
 
         private class AutoPropertyInjectorMockHandler : MockHandler
         {
-            public override void OnMockCreated(object instance, Type type, IComponentContext context)
+            public override void OnMockCreated(object instance, Type type, IComponentContext context, ISubstitutionContext substitutionContext)
             {
-                var router = SubstitutionContext.Current.GetCallRouterFor(instance);
+                var router = substitutionContext.GetCallRouterFor(instance);
 
                 router.RegisterCustomCallHandlerFactory(_ => new AutoPropertyInjectorCallHandler(context));
             }

--- a/AutofacContrib.NSubstitute/AutoSubstituteOptionsExtensions.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteOptionsExtensions.cs
@@ -1,0 +1,87 @@
+﻿using Autofac;
+using Autofac.Core.Activators.Reflection;
+using NSubstitute.Core;
+using System;
+using System.Reflection;
+
+namespace AutofacContrib.NSubstitute
+{
+    public static class AutoSubstituteOptionsExtensions
+    {
+        /// <summary>
+        /// Configures the auto-generated types Autofac creates to be the same throughout a lifetime scope.
+        /// </summary>
+        /// <param name="builder">A <see cref="AutoSubstituteBuilder"/></param>
+        /// <returns>The supplied <see cref="AutoSubstituteBuilder"/></returns>
+        public static AutoSubstituteBuilder MakeUnregisteredTypesPerLifetime(this AutoSubstituteBuilder builder)
+            => builder.ConfigureOptions(options =>
+            {
+                options.ConfigureAnyConcreteTypeRegistration.Add(registration => registration.InstancePerLifetimeScope());
+            });
+
+        /// <summary>
+        /// Configures the auto-generated types Autofac creates to search through internal constructors as well. If a type is explicitly registered, it will not search for internal constructors automatically.
+        /// </summary>
+        /// <param name="builder">A <see cref="AutoSubstituteBuilder"/></param>
+        /// <returns>The supplied <see cref="AutoSubstituteBuilder"/></returns>
+        public static AutoSubstituteBuilder UnregisteredTypesUseInternalConstructor(this AutoSubstituteBuilder builder)
+            => builder.ConfigureOptions(options =>
+            {
+                options.ConfigureAnyConcreteTypeRegistration.Add(registration => registration.FindConstructorsWith(NonPublicConstructorFinder.Finder));
+            });
+
+        /// <summary>
+        /// Configures the auto-generated types to populate the properties based on the configured container. If a type is explicitly registered, then the properties will not be automatically satisfied.
+        /// </summary>
+        /// <param name="builder">A <see cref="AutoSubstituteBuilder"/></param>
+        /// <returns>The supplied <see cref="AutoSubstituteBuilder"/></returns>
+        public static AutoSubstituteBuilder InjectProperties(this AutoSubstituteBuilder builder)
+            => builder.ConfigureOptions(options =>
+            {
+                options.MockHandlers.Add(new AutoPropertyInjectorMockHandler());
+                options.ConfigureAnyConcreteTypeRegistration.Add(r => r.PropertiesAutowired());
+            });
+
+        private class NonPublicConstructorFinder : DefaultConstructorFinder
+        {
+            public static IConstructorFinder Finder { get; } = new NonPublicConstructorFinder();
+
+            private NonPublicConstructorFinder()
+                : base(type => type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+            }
+        }
+
+        private class AutoPropertyInjectorMockHandler : MockHandler
+        {
+            public override void OnMockCreated(object instance, Type type, IComponentContext context)
+            {
+                var router = SubstitutionContext.Current.GetCallRouterFor(instance);
+
+                router.RegisterCustomCallHandlerFactory(_ => new AutoPropertyInjectorCallHandler(context));
+            }
+
+            private class AutoPropertyInjectorCallHandler : ICallHandler
+            {
+                private readonly IComponentContext _context;
+
+                public AutoPropertyInjectorCallHandler(IComponentContext context)
+                {
+                    _context = context;
+                }
+
+                public RouteAction Handle(ICall call)
+                {
+                    var property = call.GetMethodInfo().GetPropertyFromGetterCallOrNull();
+
+                    if (property is null)
+                    {
+                        return RouteAction.Continue();
+                    }
+
+                    return RouteAction.Return(_context.Resolve(call.GetReturnType()));
+                }
+            }
+        }
+    }
+}

--- a/AutofacContrib.NSubstitute/MockHandler.cs
+++ b/AutofacContrib.NSubstitute/MockHandler.cs
@@ -1,0 +1,23 @@
+﻿using Autofac;
+using System;
+
+namespace AutofacContrib.NSubstitute
+{
+    /// <summary>
+    /// A handler that is used to modify any of the auto-generated NSubstitute mocks.
+    /// </summary>
+    public abstract class MockHandler
+    {
+        protected MockHandler()
+        {
+        }
+
+        /// <summary>
+        /// Provides a way to manage mocks after creation but before returned from the container registry.
+        /// </summary>
+        /// <param name="instance">The mock instance.</param>
+        /// <param name="type">The type the mock was created for.</param>
+        /// <param name="context">The current component context.</param>
+        public abstract void OnMockCreated(object instance, Type type, IComponentContext context);
+    }
+}

--- a/AutofacContrib.NSubstitute/MockHandler.cs
+++ b/AutofacContrib.NSubstitute/MockHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using NSubstitute.Core;
 using System;
 
 namespace AutofacContrib.NSubstitute
@@ -18,6 +19,7 @@ namespace AutofacContrib.NSubstitute
         /// <param name="instance">The mock instance.</param>
         /// <param name="type">The type the mock was created for.</param>
         /// <param name="context">The current component context.</param>
-        public abstract void OnMockCreated(object instance, Type type, IComponentContext context);
+        /// <param name="substitutionContext">The current substitution context.</param>
+        public abstract void OnMockCreated(object instance, Type type, IComponentContext context, ISubstitutionContext substitutionContext);
     }
 }

--- a/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
+++ b/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
@@ -6,6 +6,7 @@ using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Features.Decorators;
 using NSubstitute;
+using NSubstitute.Core;
 
 namespace AutofacContrib.NSubstitute
 {
@@ -64,7 +65,7 @@ namespace AutofacContrib.NSubstitute
 
                     foreach (var handler in _options.MockHandlers)
                     {
-                        handler.OnMockCreated(instance, typedService.ServiceType, ctx);
+                        handler.OnMockCreated(instance, typedService.ServiceType, ctx, SubstitutionContext.Current);
                     }
 
                     return instance;

--- a/README.md
+++ b/README.md
@@ -228,3 +228,17 @@ If you want to make modifications to the container builder before the container 
 ```c#
 var autoSubstitute = new AutoSubstitute(cb => cb.RegisterModule<SomeModule>());
 ```
+
+Options Configuration
+---------------------
+
+There are various options that can be used to set up the container and NSubstitute in helpful ways for some scenarios.  These are exposed via the `AutoSubstituteBuilder.ConfigureOptions()` method. The options currently available:
+
+- Add custom `MockHandler` instances that can intercept the creation of the NSubstitute mocks
+- Add custom handlers for the registration of implicit service creation via `AnyConcreteTypeNotAlreadyRegisteredSource`
+
+Some convenience methods build upon this to enable a few common scenarios:
+
+- `AutoSubstituteBuilder.InjectProperties()` - This enables auto injection of properties on the NSubstitute mock from the configured container
+- `AutoSubstituteBuilder.MakeUnregisteredTypesPerLifetime()` - This configures the `AnyConcreteTypeNotAlreadyRegisteredSource` to be per lifetime scope
+- `AutoSubstituteBuilder.UnregisteredTypesUseInternalConstructor()` - This configures the `AnyConcreteTypeNotAlreadyRegisteredSource` to search for non-public constructors as well.


### PR DESCRIPTION
There are two options exposed:

1. MockHandlers - these allow injecting code to handle a mock upon creation
2. ConfigureAnyConcreteTypeRegistration - this allows modifying the options AnyConcreteTypeNotAlreadyRegisteredSource uses

As part of this, a couple of convenience methods are provided:

1. AutoSubstituteBuilder.InjectProperties() - This enables auto injection of properties on the NSubstitute mock from the configured container
2. AutoSubstituteBuilder.MakeUnregisteredTypesPerLifetime() - This configures the AnyConcreteTypeNotAlreadyRegisteredSource  to be per lifetime scope
3. AutoSubstituteBuilder.UnregisteredTypesUseInternalConstructor() - This configures the AnyConcreteTypeNotAlreadyRegisteredSource to search for non-public constructors as well.

Fixes #1 
Fixes #2 