### PR TITLE
Allow customization of which mocks to generate

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/TypesToSkipForMockingFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/TypesToSkipForMockingFixture.cs
@@ -1,0 +1,67 @@
+﻿using Autofac.Core.Registration;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace AutofacContrib.NSubstitute.Tests
+{
+    [TestFixture]
+    public class TypesToSkipForMockingFixture
+    {
+        [Test]
+        public void WithoutOption()
+        {
+            var mock = AutoSubstitute.Configure()
+                .Provide<IDependency, Impl1>(out var impl1)
+                .Provide<IDependency, Impl2>(out var impl2)
+                .Build();
+
+            var items = mock.Resolve<IDependency[]>();
+
+            Assert.AreEqual(impl1.Value, items[0]);
+            Assert.AreEqual(impl2.Value, items[1]);
+            Assert.That(items[2], Is.NSubstituteMock);
+        }
+
+        [Test]
+        public void ManuallyAddTypeToSkip()
+        {
+            var mock = AutoSubstitute.Configure()
+                .ConfigureOptions(options =>
+                {
+                    options.TypesToSkipForMocking.Add(typeof(IDependency));
+                })
+                .Build();
+
+            Assert.Throws<ComponentNotRegisteredException>(() => mock.Resolve<IDependency>());
+        }
+
+        [Test]
+        public void DisableMockGenerationOnProvide()
+        {
+            var mock = AutoSubstitute.Configure()
+                .ConfigureOptions(options =>
+                {
+                    options.AutomaticallySkipMocksForProvidedValues = true;
+                })
+                .Provide<IDependency, Impl1>(out var impl1)
+                .Provide<IDependency, Impl2>(out var impl2)
+                .Build();
+
+            var items = mock.Resolve<IEnumerable<IDependency>>();
+
+            CollectionAssert.AreEqual(items, new[] { impl1.Value, impl2.Value });
+        }
+
+        public interface IDependency
+        {
+        }
+
+        public class Impl1 : IDependency
+        {
+        }
+
+        public class Impl2 : IDependency
+        {
+        }
+    }
+}

--- a/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
@@ -91,6 +91,8 @@ namespace AutofacContrib.NSubstitute
 
             providedValue = CreateProvidedValue<TService>(c => c.ResolveKeyed<TService>(key));
 
+            SkipMockIfNeeded<TService>();
+
             return this;
         }
 
@@ -104,6 +106,8 @@ namespace AutofacContrib.NSubstitute
             where TService : class
         {
             _builder.RegisterInstance(instance);
+
+            SkipMockIfNeeded<TService>();
 
             return this;
         }
@@ -162,6 +166,14 @@ namespace AutofacContrib.NSubstitute
                 .InstancePerLifetimeScope();
 
             return this;
+        }
+
+        private void SkipMockIfNeeded<T>()
+        {
+            if (_options.AutomaticallySkipMocksForProvidedValues)
+            {
+                _options.TypesToSkipForMocking.Add(typeof(T));
+            }
         }
 
         private SubstituteForBuilder<TService> CreateSubstituteForBuilder<TService>(Func<TService> factory, bool isSubstituteFor)

--- a/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
@@ -14,6 +14,16 @@ namespace AutofacContrib.NSubstitute
         /// <summary>
         /// Gets a collection of delegates that can augment the registrations of objects created but not registered.
         /// </summary>
-        public ICollection<Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>> ConfigureAnyConcreteTypeRegistration { get; } = new List<Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>>(); 
+        public ICollection<Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>> ConfigureAnyConcreteTypeRegistration { get; } = new List<Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>>();
+
+        /// <summary>
+        /// Gets a collection of types that will be skipped during generation of NSubstitute mocks.
+        /// </summary>
+        public ICollection<Type> TypesToSkipForMocking { get; } = new HashSet<Type>();
+
+        /// <summary>
+        /// Gets or sets a flag indicating whether mocks should be excluded for provided values. This will automatically add values given to Provide methods to <see cref="TypesToSkipForMocking"/>.
+        /// </summary>
+        public bool AutomaticallySkipMocksForProvidedValues { get; set; }
     }
 }

--- a/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
+++ b/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
@@ -46,9 +46,12 @@ namespace AutofacContrib.NSubstitute
             (Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (service == null)
-                throw new ArgumentNullException("service");
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
 
             var typedService = service as IServiceWithType;
+
             if (typedService == null ||
                 !typedService.ServiceType.IsInterface ||
                 IsGenericListOrCollectionInterface(typedService.ServiceType) ||
@@ -56,6 +59,11 @@ namespace AutofacContrib.NSubstitute
                 typeof(IStartable).IsAssignableFrom(typedService.ServiceType) ||
                 service is DecoratorService)
                 return Enumerable.Empty<IComponentRegistration>();
+
+            if (_options.TypesToSkipForMocking.Contains(typedService.ServiceType))
+            {
+                return Enumerable.Empty<IComponentRegistration>();
+            }
 
             var rb = RegistrationBuilder
                 .ForDelegate((c, p) =>

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,3 +1,3 @@
 mode: ContinuousDelivery
-next-version: 6.0.0
+next-version: 6.1.0
 branches: {}

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ public void Example_test_with_concrete_object_provide()
 }
 ```
 
+### NSubstitute Helpers
+
 There is also a convenient syntax for registering and resolving a `Substitute.For<T>()` with the underlying container for concrete classes:
 
 ```c#
@@ -265,6 +267,8 @@ public void Example_test_with_substitute_for_concrete_resolved_from_autofac()
 }
 ```
 
+### Direct configuration with ContainerBuilder
+
 If you need to access the underlying Autofac container for some reason then you use the `Container` property on the `AutoSubstitute` object.
 
 If you want to make modifications to the container builder before the container is build from it there is a second constructor parameter you can use, for example:
@@ -280,6 +284,8 @@ There are various options that can be used to set up the container and NSubstitu
 
 - Add custom `MockHandler` instances that can intercept the creation of the NSubstitute mocks
 - Add custom handlers for the registration of implicit service creation via `AnyConcreteTypeNotAlreadyRegisteredSource`
+- Add types that will be skipped during the mock generation via `TypesToSkipForMocking` option
+- Automatically skip mock generation of types that are specified in Provide methods via `AutomaticallySkipMocksForProvidedValues`
 
 Some convenience methods build upon this to enable a few common scenarios:
 


### PR DESCRIPTION
Adds an option to not generate mocks of provided values. This will automatically add types to a new collection on the options object, which can also be added to manually to prevent mocks of that type from being generated.

Fixes #32 