### PR TITLE
Add helper method to disable base calls on substitutes

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/AutoSubstituteOptionsFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/AutoSubstituteOptionsFixture.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Autofac.Core;
 using NUnit.Framework;
+using System;
 
 namespace AutofacContrib.NSubstitute.Tests
 {
@@ -106,6 +107,33 @@ namespace AutofacContrib.NSubstitute.Tests
                 .Container;
 
             Assert.NotNull(mock.Resolve<ClassWithInternalConstructor>());
+        }
+
+        [Test]
+        public void BaseCalledByDefault()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .SubstituteForPartsOf<ClassWithBase>().Configured()
+                .Build()
+                .Container;
+
+            Assert.Throws<InvalidOperationException>(() => mock.Resolve<ClassWithBase>().Throws());
+        }
+
+        [Test]
+        public void BaseCallDisabled()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .SubstituteForPartsOf<ClassWithBase>().DoNotCallBase().Configured()
+                .Build()
+                .Container;
+
+            Assert.Null(mock.Resolve<ClassWithBase>().Throws());
+        }
+
+        public abstract class ClassWithBase
+        {
+            public virtual object Throws() => throw new InvalidOperationException();
         }
 
         public interface ITestInterface1

--- a/AutofacContrib.NSubstitute.Tests/SubstituteForFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/SubstituteForFixture.cs
@@ -3,8 +3,6 @@ using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AutofacContrib.NSubstitute.Tests
 {

--- a/AutofacContrib.NSubstitute.Tests/SubstituteForFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/SubstituteForFixture.cs
@@ -90,9 +90,61 @@ namespace AutofacContrib.NSubstitute.Tests
             Assert.Throws<InvalidOperationException>(() => builder.SubstituteFor<Test1>());
         }
 
+        [Test]
+        public void PropertiesNotSetByDefault()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .Provide<IProperty, CustomProperty>(out _)
+                .SubstituteFor<TestWithProperty>().Configured()
+                .Build();
+
+            Assert.IsNull(mock.Resolve<TestWithProperty>().PropertySetter);
+            Assert.That(mock.Resolve<TestWithProperty>().VirtualProperty, Is.NSubstituteMock);
+        }
+
+        [Test]
+        public void PropertiesSetIfRequested()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .Provide<IProperty, CustomProperty>(out var property)
+                .SubstituteFor<TestWithProperty>()
+                    .InjectProperties()
+                    .Configured()
+                .Build();
+
+            Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);
+            Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().VirtualProperty);
+        }
+
+        [Test]
+        public void PropertiesSetIfGloballyRequested()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .InjectProperties()
+                .Provide<IProperty, CustomProperty>(out var property)
+                .SubstituteFor<TestWithProperty>().Configured()
+                .Build();
+
+            Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);
+            Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().VirtualProperty);
+        }
+
         public abstract class Test1
         {
             public virtual object Throws() => throw new InvalidOperationException();
         }
+
+        public abstract class TestWithProperty
+        {
+            public IProperty PropertySetter { get; set; }
+
+            public virtual IProperty VirtualProperty { get; }
+        }
+
+        public interface IProperty
+        {
+        }
+
+        public class CustomProperty : IProperty { }
     }
 }

--- a/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
@@ -186,6 +186,11 @@ namespace AutofacContrib.NSubstitute
 
             _substituteForRegistrations.Add(typeof(TService), builder);
 
+            if (_options.AutoInjectProperties)
+            {
+                builder.InjectProperties();
+            }
+
             return builder;
         }
 

--- a/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
@@ -6,6 +6,8 @@ namespace AutofacContrib.NSubstitute
 {
     public class AutoSubstituteOptions
     {
+        internal bool AutoInjectProperties { get; set; }
+
         /// <summary>
         /// Gets a collection of handlers that can be used to modify mocks after they are created.
         /// </summary>

--- a/AutofacContrib.NSubstitute/MockHandlers/AutoPropertyInjectorMockHandler.cs
+++ b/AutofacContrib.NSubstitute/MockHandlers/AutoPropertyInjectorMockHandler.cs
@@ -1,0 +1,44 @@
+﻿using Autofac;
+using NSubstitute.Core;
+using System;
+
+namespace AutofacContrib.NSubstitute
+{
+    internal class AutoPropertyInjectorMockHandler : MockHandler
+    {
+        public static AutoPropertyInjectorMockHandler Instance { get; } = new AutoPropertyInjectorMockHandler();
+
+        private AutoPropertyInjectorMockHandler()
+        {
+        }
+
+        protected internal override void OnMockCreated(object instance, Type type, IComponentContext context, ISubstitutionContext substitutionContext)
+        {
+            var router = substitutionContext.GetCallRouterFor(instance);
+
+            router.RegisterCustomCallHandlerFactory(_ => new AutoPropertyInjectorCallHandler(context));
+        }
+
+        private class AutoPropertyInjectorCallHandler : ICallHandler
+        {
+            private readonly IComponentContext _context;
+
+            public AutoPropertyInjectorCallHandler(IComponentContext context)
+            {
+                _context = context;
+            }
+
+            public RouteAction Handle(ICall call)
+            {
+                var property = call.GetMethodInfo().GetPropertyFromGetterCallOrNull();
+
+                if (property is null)
+                {
+                    return RouteAction.Continue();
+                }
+
+                return RouteAction.Return(_context.Resolve(call.GetReturnType()));
+            }
+        }
+    }
+}

--- a/AutofacContrib.NSubstitute/SubstituteForBuilder.cs
+++ b/AutofacContrib.NSubstitute/SubstituteForBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Autofac.Builder;
+using NSubstitute.Core;
 using System;
 
 namespace AutofacContrib.NSubstitute
@@ -29,6 +30,8 @@ namespace AutofacContrib.NSubstitute
         /// </summary>
         internal bool IsSubstituteFor { get; }
 
+        internal ISubstitutionContext Context => SubstitutionContext.Current;
+
         /// <summary>
         /// Allows for configuration of the service.
         /// </summary>
@@ -46,7 +49,7 @@ namespace AutofacContrib.NSubstitute
         {
             _registration.OnActivated(args =>
             {
-                action(args.Instance, args.Context);
+                action(args.Instance, args.Context.Resolve<IComponentContext>());
             });
 
             return _builder;

--- a/AutofacContrib.NSubstitute/SubstituteForBuilderExtensions.cs
+++ b/AutofacContrib.NSubstitute/SubstituteForBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using NSubstitute.Core;
+using Autofac;
 
 namespace AutofacContrib.NSubstitute
 {
@@ -18,6 +19,18 @@ namespace AutofacContrib.NSubstitute
                 var router = SubstitutionContext.Current.GetCallRouterFor(t);
 
                 router.CallBaseByDefault = false;
+            });
+
+            return builder;
+        }
+
+        public static SubstituteForBuilder<T> InjectProperties<T>(this SubstituteForBuilder<T> builder)
+            where T : class
+        {
+            builder.Configure((t, ctx) =>
+            {
+                ctx.InjectUnsetProperties(t);
+                AutoPropertyInjectorMockHandler.Instance.OnMockCreated(t, typeof(T), ctx, builder.Context);
             });
 
             return builder;

--- a/AutofacContrib.NSubstitute/SubstituteForBuilderExtensions.cs
+++ b/AutofacContrib.NSubstitute/SubstituteForBuilderExtensions.cs
@@ -1,0 +1,26 @@
+﻿using NSubstitute.Core;
+
+namespace AutofacContrib.NSubstitute
+{
+    public static class SubstituteForBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the auto-generated instance of <typeparamref name="T"/> to not call the base method for any of the methods.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static SubstituteForBuilder<T> DoNotCallBase<T>(this SubstituteForBuilder<T> builder)
+            where T : class
+        {
+            builder.Configure(t =>
+            {
+                var router = SubstitutionContext.Current.GetCallRouterFor(t);
+
+                router.CallBaseByDefault = false;
+            });
+
+            return builder;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -229,6 +229,38 @@ public void BaseCalledOnSubstituteForPartsOf()
 }
 ```
 
+You can also enforce all properties to be automatically injected on this substitute:
+
+```c#
+[Test]
+public void PropertiesSetIfRequested()
+{
+	using var mock = AutoSubstitute.Configure()
+		.Provide<IProperty, CustomProperty>(out var property)
+		.SubstituteFor<TestWithProperty>()
+			.InjectProperties()
+			.Configured()
+		.Build();
+
+	Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);
+	Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().VirtualProperty);
+}
+
+[Test]
+public void PropertiesSetIfGloballyRequested()
+{
+	using var mock = AutoSubstitute.Configure()
+		.InjectProperties()
+		.Provide<IProperty, CustomProperty>(out var property)
+		.SubstituteFor<TestWithProperty>().Configured()
+		.Build();
+
+	Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);
+	Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().VirtualProperty);
+}
+
+```
+
 Similarly, you can resolve a concrete type from the AutoSubstitute container and register that with the underlying container using the `ResolveAndSubstituteFor` method:
 
 ```c#

--- a/README.md
+++ b/README.md
@@ -208,6 +208,27 @@ public void BaseCalledOnSubstituteForPartsOf()
 }
 ```
 
+There is a helper method to ensure base calls are not routed by default for any method on partial substitutes if desired:
+
+```c#
+public abstract class Test1
+{
+	public virtual object Throws() => throw new InvalidOperationException();
+}
+
+[Test]
+public void BaseCalledOnSubstituteForPartsOf()
+{
+    using var mock = AutoSubstitute.Configure()
+        .SubstituteForPartsOf<Test1>().DoNotCallBase().Configured()
+        .Build();
+
+    var test1 = mock.Resolve<Test1>();
+
+    Assert.IsNull(test1.Throws());
+}
+```
+
 Similarly, you can resolve a concrete type from the AutoSubstitute container and register that with the underlying container using the `ResolveAndSubstituteFor` method:
 
 ```c#


### PR DESCRIPTION
This also adds the auto-injection of parameters as an option to automatically configure for substitutes.