### PR TITLE
Layer SubstituteForBuilder on top of AutoSubstituteBuilder

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/AutoSubstituteOptionsFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/AutoSubstituteOptionsFixture.cs
@@ -113,7 +113,7 @@ namespace AutofacContrib.NSubstitute.Tests
         public void BaseCalledByDefault()
         {
             using var mock = AutoSubstitute.Configure()
-                .SubstituteForPartsOf<ClassWithBase>().Configured()
+                .SubstituteForPartsOf<ClassWithBase>()
                 .Build()
                 .Container;
 
@@ -124,7 +124,7 @@ namespace AutofacContrib.NSubstitute.Tests
         public void BaseCallDisabled()
         {
             using var mock = AutoSubstitute.Configure()
-                .SubstituteForPartsOf<ClassWithBase>().DoNotCallBase().Configured()
+                .SubstituteForPartsOf<ClassWithBase>().DoNotCallBase()
                 .Build()
                 .Container;
 

--- a/AutofacContrib.NSubstitute.Tests/ExampleFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/ExampleFixture.cs
@@ -1,7 +1,7 @@
 ﻿using Autofac;
 using NSubstitute;
-using NSubstitute.Extensions;
 using NUnit.Framework;
+using System;
 
 namespace AutofacContrib.NSubstitute.Tests
 {
@@ -167,16 +167,15 @@ namespace AutofacContrib.NSubstitute.Tests
         }
 
         [Test]
+        [Obsolete]
         public void Example_test_with_substitute_for_concrete_resolved_from_autofac()
         {
             const int val1 = 2;
             const int val2 = 3;
             const int val3 = 4;
 
-#pragma warning disable CS0618 // Type or member is obsolete
             using var mock = AutoSubstitute.Configure()
                 .ResolveAndSubstituteFor<ConcreteClassWithDependency>(new TypedParameter(typeof(int), val1))
-#pragma warning restore CS0618 // Type or member is obsolete
                 .Build();
 
             mock.Resolve<IDependency2>().SomeOtherMethod().Returns(val2);

--- a/AutofacContrib.NSubstitute.Tests/SubstituteForFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/SubstituteForFixture.cs
@@ -10,7 +10,8 @@ namespace AutofacContrib.NSubstitute.Tests
     public class SubstituteForFixture
     {
         [Test]
-        public void Example_test_with_substitute_for_concrete()
+        [Obsolete]
+        public void Example_test_with_substitute_for_concrete_obsolete()
         {
             const int val1 = 3;
             const int val2 = 2;
@@ -28,13 +29,31 @@ namespace AutofacContrib.NSubstitute.Tests
         }
 
         [Test]
+        public void Example_test_with_substitute_for_concrete()
+        {
+            const int val1 = 3;
+            const int val2 = 2;
+            const int val3 = 10;
+
+            using var utoSubstitute = AutoSubstitute.Configure()
+                .SubstituteFor<ConcreteClass>(val2).ConfigureSubstitute(c => c.Add(Arg.Any<int>()).Returns(val3))
+                .Build();
+
+            utoSubstitute.Resolve<IDependency2>().SomeOtherMethod().Returns(val1);
+
+            var result = utoSubstitute.Resolve<MyClassWithConcreteDependency>().AMethod();
+
+            Assert.That(result, Is.EqualTo(val3));
+        }
+
+        [Test]
         public void SubstituteForConfigureWithContext()
         {
             const int val = 2;
 
             using var utoSubstitute = AutoSubstitute.Configure()
-                .SubstituteFor<ConcreteClass>(val).Configured()
-                .SubstituteFor<ConcreteClassWithObject>().Configure((s, ctx) =>
+                .SubstituteFor<ConcreteClass>(val)
+                .SubstituteFor<ConcreteClassWithObject>().ConfigureSubstitute((s, ctx) =>
                 {
                     s.Configure().GetResult().Returns(ctx.Resolve<ConcreteClass>());
                 })
@@ -50,7 +69,7 @@ namespace AutofacContrib.NSubstitute.Tests
         public void BaseCalledOnSubstituteForPartsOf()
         {
             using var mock = AutoSubstitute.Configure()
-                .SubstituteForPartsOf<Test1>().Configured()
+                .SubstituteForPartsOf<Test1>()
                 .Build();
 
             var test1 = mock.Resolve<Test1>();
@@ -63,7 +82,7 @@ namespace AutofacContrib.NSubstitute.Tests
         public void BaseNotCalledOnSubstituteFor()
         {
             using var mock = AutoSubstitute.Configure()
-                .SubstituteFor<Test1>().Configured()
+                .SubstituteFor<Test1>()
                 .Build();
 
             var test1 = mock.Resolve<Test1>();
@@ -76,7 +95,7 @@ namespace AutofacContrib.NSubstitute.Tests
         public void FailsIfSubstituteTypeIsChanged()
         {
             var builder = AutoSubstitute.Configure()
-                .SubstituteFor<Test1>().Configured();
+                .SubstituteFor<Test1>();
 
             Assert.Throws<InvalidOperationException>(() => builder.SubstituteForPartsOf<Test1>());
         }
@@ -85,7 +104,7 @@ namespace AutofacContrib.NSubstitute.Tests
         public void FailsIfSubstituteTypeIsChanged2()
         {
             var builder = AutoSubstitute.Configure()
-                .SubstituteForPartsOf<Test1>().Configured();
+                .SubstituteForPartsOf<Test1>();
 
             Assert.Throws<InvalidOperationException>(() => builder.SubstituteFor<Test1>());
         }
@@ -95,7 +114,7 @@ namespace AutofacContrib.NSubstitute.Tests
         {
             using var mock = AutoSubstitute.Configure()
                 .Provide<IProperty, CustomProperty>(out _)
-                .SubstituteFor<TestWithProperty>().Configured()
+                .SubstituteFor<TestWithProperty>()
                 .Build();
 
             Assert.IsNull(mock.Resolve<TestWithProperty>().PropertySetter);
@@ -109,7 +128,6 @@ namespace AutofacContrib.NSubstitute.Tests
                 .Provide<IProperty, CustomProperty>(out var property)
                 .SubstituteFor<TestWithProperty>()
                     .InjectProperties()
-                    .Configured()
                 .Build();
 
             Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);
@@ -122,7 +140,7 @@ namespace AutofacContrib.NSubstitute.Tests
             using var mock = AutoSubstitute.Configure()
                 .InjectProperties()
                 .Provide<IProperty, CustomProperty>(out var property)
-                .SubstituteFor<TestWithProperty>().Configured()
+                .SubstituteFor<TestWithProperty>()
                 .Build();
 
             Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);

--- a/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
@@ -14,12 +14,27 @@ namespace AutofacContrib.NSubstitute
         private readonly ContainerBuilder _builder;
         private readonly AutoSubstituteOptions _options;
 
+        /// <summary>
+        /// Create a new instance of the builder.
+        /// </summary>
         public AutoSubstituteBuilder()
         {
             _substituteForRegistrations = new Dictionary<Type, object>();
             _afterBuildActions = new List<Action<IComponentContext>>();
             _builder = new ContainerBuilder();
             _options = new AutoSubstituteOptions();
+        }
+       
+        /// <summary>
+        /// Creates a new instance that allows linking to the previous instance for derived builders.
+        /// </summary>
+        /// <param name="other">A <see cref="AutoSubstituteBuilder"/> that should be connected to this instance</param>
+        private protected AutoSubstituteBuilder(AutoSubstituteBuilder other)
+        {
+            _substituteForRegistrations = other._substituteForRegistrations;
+            _afterBuildActions = other._afterBuildActions;
+            _builder = other._builder;
+            _options = other._options;
         }
 
         /// <summary>
@@ -274,7 +289,7 @@ namespace AutofacContrib.NSubstitute
             return builder;
         }
 
-        internal IProvidedValue<TService> CreateProvidedValue<TService>(Func<IComponentContext, TService> factory)
+        private protected IProvidedValue<TService> CreateProvidedValue<TService>(Func<IComponentContext, TService> factory)
         {
             var value = new ProvidedValue<TService>(factory);
 

--- a/AutofacContrib.NSubstitute/SubstituteForBuilderExtensions.cs
+++ b/AutofacContrib.NSubstitute/SubstituteForBuilderExtensions.cs
@@ -13,27 +13,19 @@ namespace AutofacContrib.NSubstitute
         /// <returns></returns>
         public static SubstituteForBuilder<T> DoNotCallBase<T>(this SubstituteForBuilder<T> builder)
             where T : class
-        {
-            builder.Configure(t =>
+            => builder.ConfigureSubstitute(t =>
             {
                 var router = SubstitutionContext.Current.GetCallRouterFor(t);
 
                 router.CallBaseByDefault = false;
             });
 
-            return builder;
-        }
-
         public static SubstituteForBuilder<T> InjectProperties<T>(this SubstituteForBuilder<T> builder)
             where T : class
-        {
-            builder.Configure((t, ctx) =>
+            => builder.ConfigureSubstitute((t, ctx) =>
             {
                 ctx.InjectUnsetProperties(t);
                 AutoPropertyInjectorMockHandler.Instance.OnMockCreated(t, typeof(T), ctx, builder.Context);
             });
-
-            return builder;
-        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ public void Example_test_with_substitute_for_concrete()
     const int val2 = 2;
     const int val3 = 10;
     using var autoSubstitute = AutoSubstitute.Configure()
-        .SubstituteFor<ConcreteClass>(val2).Configure(c => c.Add(Arg.Any<int>()).Returns(val3))
+        .SubstituteFor<ConcreteClass>(val2).ConfigureSubstitute(c => c.Add(Arg.Any<int>()).Returns(val3))
         .Build();
     autoSubstitute.Resolve<IDependency2>().SomeOtherMethod().Returns(val1);
 
@@ -183,8 +183,8 @@ public void SubstituteForConfigureWithContext()
 	const int val = 2;
 
 	using var utoSubstitute = AutoSubstitute.Configure()
-		.SubstituteFor<ConcreteClass>(val).Configured()
-		.SubstituteFor<ConcreteClassWithObject>().Configure((s, ctx) =>
+		.SubstituteFor<ConcreteClass>(val)
+		.SubstituteFor<ConcreteClassWithObject>().ConfigureSubstitute((s, ctx) =>
 		{
 			s.Configure().GetResult().Returns(ctx.Resolve<ConcreteClass>());
 		})
@@ -209,7 +209,7 @@ public abstract class Test1
 public void BaseCalledOnSubstituteForPartsOf()
 {
     using var mock = AutoSubstitute.Configure()
-        .SubstituteForPartsOf<Test1>().Configured()
+        .SubstituteForPartsOf<Test1>()
         .Build();
 
     var test1 = mock.Resolve<Test1>();
@@ -230,7 +230,7 @@ public abstract class Test1
 public void BaseCalledOnSubstituteForPartsOf()
 {
     using var mock = AutoSubstitute.Configure()
-        .SubstituteForPartsOf<Test1>().DoNotCallBase().Configured()
+        .SubstituteForPartsOf<Test1>().DoNotCallBase()
         .Build();
 
     var test1 = mock.Resolve<Test1>();
@@ -249,7 +249,6 @@ public void PropertiesSetIfRequested()
 		.Provide<IProperty, CustomProperty>(out var property)
 		.SubstituteFor<TestWithProperty>()
 			.InjectProperties()
-			.Configured()
 		.Build();
 
 	Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);
@@ -262,7 +261,7 @@ public void PropertiesSetIfGloballyRequested()
 	using var mock = AutoSubstitute.Configure()
 		.InjectProperties()
 		.Provide<IProperty, CustomProperty>(out var property)
-		.SubstituteFor<TestWithProperty>().Configured()
+		.SubstituteFor<TestWithProperty>()
 		.Build();
 
 	Assert.AreEqual(property.Value, mock.Resolve<TestWithProperty>().PropertySetter);


### PR DESCRIPTION
This greatly simplifies some of the registration code as now there is no need to call `.Configure(...)` or `.Configured()` to continue registering other types when setting up a substitute (especially when there is no need to do anything beyond instruct the system to generate it with `SubstituteFor{PartsOf}`). Since `.Configured()` was never released publicly, this is now removed, while `.Configure(...)` is obsoleted with a new API `.ConfigureSubsitute` introduced which returns the current `SubstituteForBuilder`.

The new succinct syntax is much more fluid, and doesn't break currently built tests.