### PR TITLE
Skip substitution creation if type is already registered

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/AutoSubstituteCollectionFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/AutoSubstituteCollectionFixture.cs
@@ -150,5 +150,27 @@ namespace AutofacContrib.NSubstitute.Tests
             Assert.That(component.ServiceItems.Contains(mockA.Value), Is.True);
             Assert.That(component.ServiceItems.Contains(mockB.Value), Is.True);
         }
+
+        [Test]
+        public void OpenGenericResolvesCorrectly()
+        {
+            using var mock = AutoSubstitute.Configure()
+                .ConfigureBuilder(b => b
+                    .RegisterGeneric(typeof(OpenGeneric<>))
+                    .As(typeof(IOpenGeneric<>)))
+                .Build();
+
+            var open = mock.Resolve<IOpenGeneric<string>>();
+
+            Assert.That(open, Is.TypeOf<OpenGeneric<string>>());
+        }
+
+        public class OpenGeneric<T> : IOpenGeneric<T>
+        {
+        }
+
+        public interface IOpenGeneric<T>
+        {
+        }
     }
 }

--- a/AutofacContrib.NSubstitute.Tests/TypesToSkipForMockingFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/TypesToSkipForMockingFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac.Core.Registration;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 
 namespace AutofacContrib.NSubstitute.Tests
@@ -17,12 +18,13 @@ namespace AutofacContrib.NSubstitute.Tests
 
             var items = mock.Resolve<IDependency[]>();
 
+            Assert.AreEqual(2, items.Length);
             Assert.AreEqual(impl1.Value, items[0]);
             Assert.AreEqual(impl2.Value, items[1]);
-            Assert.That(items[2], Is.NSubstituteMock);
         }
 
         [Test]
+        [Obsolete]
         public void ManuallyAddTypeToSkip()
         {
             var mock = AutoSubstitute.Configure()
@@ -36,13 +38,9 @@ namespace AutofacContrib.NSubstitute.Tests
         }
 
         [Test]
-        public void DisableMockGenerationOnProvide()
+        public void RegisteredTypesAreNotMocked()
         {
             var mock = AutoSubstitute.Configure()
-                .ConfigureOptions(options =>
-                {
-                    options.AutomaticallySkipMocksForProvidedValues = true;
-                })
                 .Provide<IDependency, Impl1>(out var impl1)
                 .Provide<IDependency, Impl2>(out var impl2)
                 .Build();

--- a/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteBuilder.cs
@@ -172,8 +172,6 @@ namespace AutofacContrib.NSubstitute
 
             providedValue = CreateProvidedValue<TService>(c => c.ResolveKeyed<TService>(key));
 
-            SkipMockIfNeeded<TService>();
-
             return this;
         }
 
@@ -187,8 +185,6 @@ namespace AutofacContrib.NSubstitute
             where TService : class
         {
             _builder.RegisterInstance(instance);
-
-            SkipMockIfNeeded<TService>();
 
             return this;
         }
@@ -249,14 +245,6 @@ namespace AutofacContrib.NSubstitute
                 .InstancePerLifetimeScope();
 
             return this;
-        }
-
-        private void SkipMockIfNeeded<T>()
-        {
-            if (_options.AutomaticallySkipMocksForProvidedValues)
-            {
-                _options.TypesToSkipForMocking.Add(typeof(T));
-            }
         }
 
         private SubstituteForBuilder<TService> CreateSubstituteForBuilder<TService>(Func<TService> factory, bool isSubstituteFor)

--- a/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
+++ b/AutofacContrib.NSubstitute/AutoSubstituteOptions.cs
@@ -2,12 +2,13 @@
 using Autofac.Builder;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace AutofacContrib.NSubstitute
 {
     public class AutoSubstituteOptions
     {
-        private readonly static Func<ContainerBuilder, IContainer> _defaultContainerBuilder = b => b.Build();
+        private readonly static Func<ContainerBuilder, Autofac.IContainer> _defaultContainerBuilder = b => b.Build();
 
         internal bool AutoInjectProperties { get; set; }
 
@@ -24,16 +25,20 @@ namespace AutofacContrib.NSubstitute
         /// <summary>
         /// Gets a collection of types that will be skipped during generation of NSubstitute mocks.
         /// </summary>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ICollection<Type> TypesToSkipForMocking { get; } = new HashSet<Type>();
 
         /// <summary>
         /// Gets or sets a flag indicating whether mocks should be excluded for provided values. This will automatically add values given to Provide methods to <see cref="TypesToSkipForMocking"/>.
         /// </summary>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool AutomaticallySkipMocksForProvidedValues { get; set; }
 
         /// <summary>
         /// Gets or sets a factory to create an <see cref="IContainer"/> given a <see cref="ContainerBuilder"/>. This defaults to simply calling <see cref="ContainerBuilder.Build()"/>.
         /// </summary>
-        public Func<ContainerBuilder, IContainer> BuildContainerFactory { get; set; } = _defaultContainerBuilder;
+        public Func<ContainerBuilder, Autofac.IContainer> BuildContainerFactory { get; set; } = _defaultContainerBuilder;
     }
 }

--- a/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
+++ b/AutofacContrib.NSubstitute/NSubstituteRegistrationHandler.cs
@@ -60,7 +60,14 @@ namespace AutofacContrib.NSubstitute
                 service is DecoratorService)
                 return Enumerable.Empty<IComponentRegistration>();
 
+#pragma warning disable CS0612 // Type or member is obsolete
             if (_options.TypesToSkipForMocking.Contains(typedService.ServiceType))
+#pragma warning restore CS0612 // Type or member is obsolete
+            {
+                return Enumerable.Empty<IComponentRegistration>();
+            }
+
+            if (registrationAccessor(service).Any())
             {
                 return Enumerable.Empty<IComponentRegistration>();
             }


### PR DESCRIPTION
This checks if there are any registrations available while creating the mock. This allows things like open generics to be registered and not overridden by mocks.