### PR TITLE
Enable custom extension of AutoSubstituteBuilder

### DIFF
--- a/AutofacContrib.NSubstitute.Tests/CustomAutoSubstituteExtensionFixture.cs
+++ b/AutofacContrib.NSubstitute.Tests/CustomAutoSubstituteExtensionFixture.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace AutofacContrib.NSubstitute.Tests
+{
+    [TestFixture]
+    public sealed class CustomAutoSubstituteExtensionFixture
+    {
+        [Test]
+        public void CusomExtensionCanAccessData()
+        {
+            var builder = AutoSubstitute.Configure();
+            var custom1 = new CustomExtensionBuilder(builder);
+            var substituted = builder.SubstituteFor<ITest>();
+            var custom2 = new CustomExtensionBuilder(substituted);
+
+            Assert.AreSame(custom1.Data, custom2.Data);
+        }
+
+        private class CustomExtensionBuilder : AutoSubstituteBuilder
+        {
+            public CustomExtensionBuilder(AutoSubstituteBuilder other)
+                : base(other)
+            {
+            }
+
+            public CustomData Data => GetCustomData(() => new CustomData());
+        }
+
+        private class CustomData
+        {
+        }
+
+        public interface ITest
+        {
+        }
+    }
+}


### PR DESCRIPTION
This will allow users to extend with their own custom builders. This does two things:

- Make a few `private protected` methods `protected` so things like the copy constructor is available.
- Since some methods return a new builder, a new method `GetCustomData` is provided so that subclasses can store data that will be transferred to new instances